### PR TITLE
fix warning

### DIFF
--- a/resources/profile.rb
+++ b/resources/profile.rb
@@ -38,7 +38,7 @@ attribute :passphrase, kind_of: String
 attribute :passphrase_sign, kind_of: String
 attribute :compression,
           kind_of: Symbol,
-          equal_to: [:bzip2, :incremental],
+          equal_to: [:bzip2, :incremental, :none],
           default: :none
 
 attribute :volume_size, kind_of: Integer, default: 25


### PR DESCRIPTION
Default value :none is invalid for property compression of resource duply_profile. In Chef 13 this will become an error: Option compression must be equal to one of: bzip2, incremental!  You passed :none.. at 1 location:
           - /tmp/kitchen/cache/cookbooks/duply/resources/profile.rb:39:in 'class_from_file'
          See https://docs.chef.io/deprecations_custom_resource_cleanups.html for further details.