### PR TITLE
duply 0.2.3: add archive directory attribute to "profile" resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ duply_profile 'swift' do
   ]
 end
 ```
+
 Execute duply commands from the cookbook
 
 ```ruby

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'datacoda@gmail.com'
 license 'All rights reserved'
 description 'Installs/Configures duply'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.2'
+version '0.2.3'
 source_url 'https://github.com/datacoda/chef-duply'
 issues_url 'https://github.com/datacoda/chef-duply/issues'
 

--- a/resources/profile.rb
+++ b/resources/profile.rb
@@ -43,6 +43,7 @@ attribute :compression,
 
 attribute :volume_size, kind_of: Integer, default: 25
 attribute :temp_dir, kind_of: String, default: '/tmp'
+attribute :arch_dir, kind_of: String, default: nil
 
 attribute :template, kind_of: String, default: 'conf.erb'
 attribute :cookbook, kind_of: String, default: 'duply'

--- a/templates/default/conf.erb
+++ b/templates/default/conf.erb
@@ -90,8 +90,9 @@ TEMP_DIR=<%= @temp_dir %>
 #       big over time so you might want to put it not in the home dir.
 # default '~/.cache/duplicity/duply_<profile>/'
 # if set  '${ARCH_DIR}/<profile>'
-#ARCH_DIR=/some/space/safe/.duply-cache
-
+<% if @arch_dir %>
+ARCH_DIR=<%= @arch_dir %>
+<% end %>
 
 # more duplicity command line options can be added in the following way
 # don't forget to leave a separating space char at the end


### PR DESCRIPTION
`ARCH_DIR` is the parent directory where the duply/duplicity cache resides.

As noted in the original script template, by default, this is `~/.cache`, which is likely to be on the root partition. This becomes problematic when the duply/duplicity cache grows in size and can lead to OS becoming unusable.