### PR TITLE
duply 0.2.4 fully plumb arch_dir

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'datacoda@gmail.com'
 license 'All rights reserved'
 description 'Installs/Configures duply'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.3'
+version '0.2.4'
 source_url 'https://github.com/datacoda/chef-duply'
 issues_url 'https://github.com/datacoda/chef-duply/issues'
 

--- a/providers/profile.rb
+++ b/providers/profile.rb
@@ -52,6 +52,7 @@ action :create do
       max_full_backups: new_resource.keep_full,
       max_fullbkp_age: new_resource.full_every,
       volsize: new_resource.volume_size,
+      arch_dir: new_resource.arch_dir,
       temp_dir: new_resource.temp_dir,
       swift_username: new_resource.swift_username,
       swift_tenant: new_resource.swift_tenant,


### PR DESCRIPTION
Apparently I forgot to add the fresh attribute to the internal `template` resource.

/cc @datacoda 